### PR TITLE
Remove dangerous compat type

### DIFF
--- a/types/absolutepath_compat.pp
+++ b/types/absolutepath_compat.pp
@@ -1,2 +1,0 @@
-# Matching the definition of stdlib's is_absolute_path
-type Tea::Absolutepath_compat = Variant[::Tea::Windowspath, Pattern[/^\//]]


### PR DESCRIPTION
This is moving to puppetlabs-stdlib, where it can follow the existing
validate_absolute_path implementation.
