### PR TITLE
port: 0 is a valid port number

### DIFF
--- a/types/port.pp
+++ b/types/port.pp
@@ -1,1 +1,1 @@
-type Tea::Port = Integer[1, 65535]
+type Tea::Port = Integer[0, 65535]


### PR DESCRIPTION
Binding to port `0` means the OS will give you a random (available) port for you to bind on.
