### PR TITLE
Add HTTPUrl type

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,6 +21,7 @@ Installing this module will make it so that puppet [auto-loads](https://docs.pup
 ## Reference
 
 ### Network related types
+* type HTTPUrl -- matches http/https URLs
 * type HTTPSUrl -- matches https URLs
 * type Port -- all valid TCP/UDP ports
 * type Privilegedport  -- ports which need rootly power to bind to

--- a/types/httpurl.pp
+++ b/types/httpurl.pp
@@ -1,0 +1,1 @@
+type Tea::HTTPUrl = Pattern[/^https?:\/\//]


### PR DESCRIPTION
Matches http and https protocols

There's one sticky point here in that a type for 'http & https' and a type for 'http-only' both want the name HTTPUrl. I figure more users will want http/https type http-only type, so it gets the name. http-only could perhaps be called 'HTTPOnlyUrl' if it's ever needed.
