### PR TITLE
Add 'alert' and 'crit' (1 and 2) severity (rfc5424)

### DIFF
--- a/types/syslogpriority.pp
+++ b/types/syslogpriority.pp
@@ -1,1 +1,1 @@
-type Tea::Syslogpriority = Enum['debug', 'info', 'notice', 'warning', 'err', 'emerg']
+type Tea::Syslogpriority = Enum['debug', 'info', 'notice', 'warning', 'err', 'crit', 'alert', 'emerg']


### PR DESCRIPTION
I think alert and crit should also be valid, no?
https://tools.ietf.org/html/rfc5424
https://en.wikipedia.org/wiki/Syslog#Severity_level